### PR TITLE
Issue/1 customize slack reaction

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,13 +110,14 @@ postMessage = () => {
     .then(reactions => {
       if (reactions.length === 0) {
         msg =
+          'Good Morning!! ' +
           oldest.format('M/D(ddd)') +
-          'のリアクションは・・・なしですyo';
+          'のリアクションは・・・なしですyo〜';
       } else {
         msg =
-          'デ、デ、デデdeででデデータ集計しましたっ！' +
+          'Good Morning!! ' +
           oldest.format('M/D(ddd)') +
-          'のリアクションですyo\n\n';
+          'のリアクション集計したyo〜\n\n';
         msg += sortResult(reactions);
       }
 
@@ -138,7 +139,7 @@ const job = new CronJob({
   Months: 0-11
   Day of Week: 0-6
   */
-  cronTime: '0 35 9 * * *',
+  cronTime: '0 0 9 * * *',
   onTick: postMessage,
   start: false,
   timeZone: 'Asia/Tokyo'

--- a/main.js
+++ b/main.js
@@ -12,14 +12,19 @@ const CronJob = require('cron').CronJob;
 
 function getChannels(oldest, latest) {
   return new Promise(function(onFulfilled, onRejected) {
-    slack.channels.list({ token: SLACK_TOKEN }).then(response => {
+    const param = {
+      token: SLACK_TOKEN,
+      exclude_archived: true,
+      types: 'public_channel, private_channel'
+    };
+    slack.conversations.list(param).then(response => {
       onFulfilled({
         channels: response.channels.map(channel => channel.id),
         oldest: oldest,
         latest: latest
       });
     });
-  });
+   });
 }
 
 function getReactions(responses) {
@@ -32,7 +37,7 @@ function getReactions(responses) {
 
     let i = 0;
     channels.map(channel => {
-      slack.channels
+      slack.conversations
         .history({
           token: SLACK_TOKEN,
           channel: channel,
@@ -56,7 +61,7 @@ function getReactions(responses) {
   });
 }
 
-sortReaction = reactions => {
+sortResult = reactions => {
   // counter
   totalReaction = [];
 
@@ -95,8 +100,8 @@ sortReaction = reactions => {
 postMessage = () => {
   // oldest ※前日0時0分
   oldest = moment()
-    .subtract(1, 'days')
-    .startOf('day');
+  .subtract(1, 'days')
+  .startOf('day');
 
   latest = moment().startOf('day');
 
@@ -105,15 +110,14 @@ postMessage = () => {
     .then(reactions => {
       if (reactions.length === 0) {
         msg =
-          'Good Morning!! ' +
           oldest.format('M/D(ddd)') +
-          'のリアクションは・・・なしですyo〜';
+          'のリアクションは・・・なしですyo';
       } else {
         msg =
-          'Good Morning!! ' +
+          'デ、デ、デデdeででデデータ集計しましたっ！' +
           oldest.format('M/D(ddd)') +
-          'のリアクション集計したyo〜\n\n';
-        msg += sortReaction(reactions);
+          'のリアクションですyo\n\n';
+        msg += sortResult(reactions);
       }
 
       console.log(msg);
@@ -134,7 +138,7 @@ const job = new CronJob({
   Months: 0-11
   Day of Week: 0-6
   */
-  cronTime: '0 0 9 * * *',
+  cronTime: '0 35 9 * * *',
   onTick: postMessage,
   start: false,
   timeZone: 'Asia/Tokyo'


### PR DESCRIPTION
# 目的 
#1 パブリックだけでなくプライベートチャンネルのリアクションも集計する
# やったこと
- チャンネルIDを取得するAPIを[channels.list](https://api.slack.com/methods/channels.list)から[conversations.list](https://api.slack.com/methods/conversations.list)に変更
- リアクション(メッセージ)を取得するAPIを[channels.history](https://api.slack.com/methods/channels.history)から[conversations.history](https://api.slack.com/methods/conversations.history)に変更
